### PR TITLE
fix(*): fix wrong urls in generated package.json and secret variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Utils included and configured:
 
 Start by creating a new repository
 and add a repository secret (under the repository settings)
-with the name of GITHUB_TOKEN
+with the name of GH_PACKAGE_TOKEN
 the token that you put there needs to have access to read/write packages.
 (if you don't have a token yet, you can create one on [https://github.com/settings/tokens](https://github.com/settings/tokens) )
 
@@ -73,3 +73,18 @@ or <br/>
 
 After this create a PR to master. this will again trigger unit testing
 once is ready, you can merge into master and this will create a new version of your package.
+
+## Using your package in an external project
+
+the new project needs to have a .npmrc file in the root folder
+with:
+
+```
+@<<your-user-name>>:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=<<READ_ONLY_TOKEN>>
+registry=https://registry.npmjs.com
+```
+
+replace \<\<your-user-name>> with your user name or your organization <br/>
+and \<\<READ_ONLY_TOKEN>> with a new token with read-only for packages <br />
+(if you don't want to store this in the repo, you can use environment variables)

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,9 +67,8 @@ const createPackageJson = (packageInfo: InquirerValues) => {
   const packageJson = {
     name: `@${packageInfo.userName}/${packageInfo.packageName}`,
     version: "1.0.0",
-    private: true,
-    types: "dist/index.d.ts",
-    main: "dist/index.js",
+    types: "dist/src/index.d.ts",
+    main: "dist/src/index.js",
     files: ["dist"],
     scripts: {
       build: "tsc",
@@ -80,15 +79,15 @@ const createPackageJson = (packageInfo: InquirerValues) => {
     },
     repository: {
       type: "git",
-      url: `git+https://github.com/$${packageInfo.userName}.${packageInfo.packageName}`,
+      url: `git+https://github.com/${packageInfo.userName}/${packageInfo.packageName}`,
     },
     keywords: [],
     author: `${packageInfo.userName}`,
     license: "ISC",
     bugs: {
-      url: `https://github.com/$${packageInfo.userName}.${packageInfo.packageName}/issues`,
+      url: `https://github.com/${packageInfo.userName}/${packageInfo.packageName}/issues`,
     },
-    homepage: `https://github.com/$${packageInfo.userName}.${packageInfo.packageName}`,
+    homepage: `https://github.com/${packageInfo.userName}/${packageInfo.packageName}`,
     publishConfig: {
       registry: `https://npm.pck.github.com/${packageInfo.userName}`,
     },

--- a/src/lib/createFiles.ts
+++ b/src/lib/createFiles.ts
@@ -60,7 +60,7 @@ const createNPMPublish = (scope: string) => {
               - run: npm ci
               - run: npm publish
                 env:
-                    NODE_AUTH_TOKEN: \${{secrets.GITHUB_TOKEN}}
+                    NODE_AUTH_TOKEN: \${{secrets.GH_PACKAGE_TOKEN}}
   `;
   fs.writeFileSync(".github/workflows/publishPackage.yml", file);
 };


### PR DESCRIPTION
github does not allows to create secrets that starts with GITHUB, so we had to change it